### PR TITLE
workflows: pin setup-ruby action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         persist-credentials: false
 
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@6bd3d993c602f6b675728ebaecb2b569ff86e99b # v1.174.0
       with:
         ruby-version: "3.2"
         bundler-cache: true


### PR DESCRIPTION
Pin the version of the `setup-ruby` action to full length commit SHA as described in the [security hardening for GitHub Actions guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions). 